### PR TITLE
AdminCP broken styles

### DIFF
--- a/1.8/faq/index.md
+++ b/1.8/faq/index.md
@@ -15,3 +15,9 @@ To fix this edit the `inc/settings.php` file and find the `$settings['bburl']` l
 Change the value to the correct URL, such as `$settings['bburl'] = "http://notmysite.com";` to `$settings['bburl'] = "http://mysite.com";`.
 
 Next, log into your Admin Control Panel > Configuration > General Configuration and update your Board URL here too.
+
+## My AdminCP has no styles / looks broken
+
+If it is only your AdminCP that looks like such and you have changed the directory name for it (from /admin to something else, for example /panel) then you should also apply the change in the `inc/config.php` file.
+
+To fix this edit the `inc/config.php` file and find the `$config['admin_dir']` line and change the value to the directory name of the admin directory, such as `$config['admin_dir'] = 'admin';` to `$config['admin_dir'] = 'panel';`


### PR DESCRIPTION
AdminCP can also show broken styles if the directory name for it is
changed, but the value of $config['admin_dir'] is not changed in
`inc/config.php
