### PR TITLE
Updated CDN tutorial to fix broken Markdown

### DIFF
--- a/1.8/faq/using-a-cdn-with-mybb.md
+++ b/1.8/faq/using-a-cdn-with-mybb.md
@@ -15,10 +15,10 @@ When setting up a CDN, you will want to choose a subdomain to use. In the case o
 
 
 Once you have created this subdomain, you should copy your current static files to it. Below is a list of the folders/files you will need to copy across in a default installation of MyBB:
-•	- cache/themes/*
-•	- images/*
-•	- uploads/*
-•	- jscripts/*
+- cache/themes/*
+- images/*
+- uploads/*
+- jscripts/*
 # Configuring your CDN
 Once these files are copied over, you should now be able to access stylesheets from the specified domain, with this done it is now time to configure your actual CDN. You should pick a provider that you prefer and trust (a list of some are listed below); however for the purposes of this tutorial, we are using “cdn.net”. 
 
@@ -32,9 +32,9 @@ The resource type should be of “pull” type and the origin should be the subdomai
 Now that our CDN is configured, it’s time to change our MyBB settings to make use of it.
 Log into your Admin Control Panel and select Configuration > Settings > Server and Optimization Options. 
 You will see the CDN settings near the bottom of the page, and can change the settings to suit your needs. In the case of this tutorial, our settings looked like this:
--	Use a CDN?: Yes
--	URL to use for static files: This is the CDN hostname that you configured in step two. In my case, it is http://cdn.mybbstuff.com
--	Path to store static files: This is the path to the subdomain that we set up earlier for static files to be stored. All uploads and stylesheets will be saved here from now on. In my case, the path is “/home/euan/webapps/s_mybbstuff_com”
+- Use a CDN?: Yes
+- URL to use for static files: This is the CDN hostname that you configured in step two. In my case, it is http://cdn.mybbstuff.com
+- Path to store static files: This is the path to the subdomain that we set up earlier for static files to be stored. All uploads and stylesheets will be saved here from now on. In my case, the path is “/home/euan/webapps/s_mybbstuff_com”
 Once configured, save your settings then reload the forum home page. All of your images, stylesheets and JavaScripts should now be loading from a CDN.
 
 


### PR DESCRIPTION
Fixed markdown in the tutorial file of using MyBB 1.8.x with a CDN.
Removed bad formatting. (Sorry!)
