### PR TITLE
Update mail.md

### DIFF
--- a/1.8/faq/mail.md
+++ b/1.8/faq/mail.md
@@ -30,6 +30,7 @@ Create a new `.php` file with this content:
        else
        {
         echo 'PHP could not send the mail';
+        print_r(error_get_last());
        }
     ?>
 ```


### PR DESCRIPTION
Added a display of the 'error_get_last()' result to the simple mail() test's failure branch. This may help some people zero in on the true cause of an elusive PHP mail() failure much more quickly, especially if mail errors are not being logged in any detail either in PHP's own error-log file, or myBB.
