### PR TITLE
Fix & reorganise redirects

### DIFF
--- a/Help-Support_eligibility.html.html
+++ b/Help-Support_eligibility.html.html
@@ -1,4 +1,0 @@
----
-layout: redirect
----
-{{ site.mainsiteurl }}/support/eligibility-policy

--- a/redirects/Help-Support_eligibility.html
+++ b/redirects/Help-Support_eligibility.html
@@ -1,0 +1,4 @@
+---
+permalink: Help-Support_eligibility.html
+redirect_to: https://mybb.com/support/eligibility-policy/
+---

--- a/redirects/versions/1.6.10.md
+++ b/redirects/versions/1.6.10.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.10/
 redirect_to: https://mybb.com/versions/1.6.10/
 ---

--- a/redirects/versions/1.6.11.md
+++ b/redirects/versions/1.6.11.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.11/
 redirect_to: https://mybb.com/versions/1.6.11/
 ---

--- a/redirects/versions/1.6.12.md
+++ b/redirects/versions/1.6.12.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.12/
 redirect_to: https://mybb.com/versions/1.6.12/
 ---

--- a/redirects/versions/1.6.13.md
+++ b/redirects/versions/1.6.13.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.13/
 redirect_to: https://mybb.com/versions/1.6.13/
 ---

--- a/redirects/versions/1.6.14.md
+++ b/redirects/versions/1.6.14.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.14/
 redirect_to: https://mybb.com/versions/1.6.14/
 ---

--- a/redirects/versions/1.6.15.md
+++ b/redirects/versions/1.6.15.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.15/
 redirect_to: https://mybb.com/versions/1.6.15/
 ---

--- a/redirects/versions/1.6.16.md
+++ b/redirects/versions/1.6.16.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.16/
 redirect_to: https://mybb.com/versions/1.6.16/
 ---

--- a/redirects/versions/1.6.17.md
+++ b/redirects/versions/1.6.17.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.17/
 redirect_to: https://mybb.com/versions/1.6.17/
 ---

--- a/redirects/versions/1.6.18.md
+++ b/redirects/versions/1.6.18.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.18/
 redirect_to: https://mybb.com/versions/1.6.18/
 ---

--- a/redirects/versions/1.6.5.md
+++ b/redirects/versions/1.6.5.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.6.5/
 redirect_to: https://mybb.com/versions/1.6.5/
 ---

--- a/redirects/versions/1.8.0.md
+++ b/redirects/versions/1.8.0.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.0/
 redirect_to: https://mybb.com/versions/1.8.0/
 ---

--- a/redirects/versions/1.8.1.md
+++ b/redirects/versions/1.8.1.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.1/
 redirect_to: https://mybb.com/versions/1.8.1/
 ---

--- a/redirects/versions/1.8.10.md
+++ b/redirects/versions/1.8.10.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.10/
 redirect_to: https://mybb.com/versions/1.8.10/
 ---

--- a/redirects/versions/1.8.11.md
+++ b/redirects/versions/1.8.11.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.11/
 redirect_to: https://mybb.com/versions/1.8.11/
 ---

--- a/redirects/versions/1.8.12.md
+++ b/redirects/versions/1.8.12.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.12/
 redirect_to: https://mybb.com/versions/1.8.12/
 ---

--- a/redirects/versions/1.8.2.md
+++ b/redirects/versions/1.8.2.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.2/
 redirect_to: https://mybb.com/versions/1.8.2/
 ---

--- a/redirects/versions/1.8.3.md
+++ b/redirects/versions/1.8.3.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.3/
 redirect_to: https://mybb.com/versions/1.8.3/
 ---

--- a/redirects/versions/1.8.4.md
+++ b/redirects/versions/1.8.4.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.4/
 redirect_to: https://mybb.com/versions/1.8.4/
 ---

--- a/redirects/versions/1.8.5.md
+++ b/redirects/versions/1.8.5.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.5/
 redirect_to: https://mybb.com/versions/1.8.5/
 ---

--- a/redirects/versions/1.8.6.md
+++ b/redirects/versions/1.8.6.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.6/
 redirect_to: https://mybb.com/versions/1.8.6/
 ---

--- a/redirects/versions/1.8.7.md
+++ b/redirects/versions/1.8.7.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.7/
 redirect_to: https://mybb.com/versions/1.8.7/
 ---

--- a/redirects/versions/1.8.8.md
+++ b/redirects/versions/1.8.8.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.8/
 redirect_to: https://mybb.com/versions/1.8.8/
 ---

--- a/redirects/versions/1.8.9.md
+++ b/redirects/versions/1.8.9.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/1.8.9/
 redirect_to: https://mybb.com/versions/1.8.9/
 ---

--- a/redirects/versions/2.0.0.md
+++ b/redirects/versions/2.0.0.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/2.0.0/
 redirect_to: https://mybb.com/versions/2.0.0/
 ---

--- a/redirects/versions/index.md
+++ b/redirects/versions/index.md
@@ -1,3 +1,4 @@
 ---
+permalink: versions/
 redirect_to: https://mybb.com/versions/
 ---


### PR DESCRIPTION
Main fix is for `Help-Support_eligibility.html`, reorganisation is moving all redirects under a `redirects` directory.