### PR TITLE
Removal of 1.6 requirements

### DIFF
--- a/1.8/install/requirements.md
+++ b/1.8/install/requirements.md
@@ -22,8 +22,6 @@ The following PHP extensions are also needed:
 - [gd](https://secure.php.net/manual/en/book.image.php)
 - [The respective vendor specific database PHP extension](https://secure.php.net/manual/en/refs.database.php)
 
-MyBB 1.6 supports PHP >= 5.0.
-
 # Recommendations
 
 Although not required, we highly recommend:


### PR DESCRIPTION
As 1.6 is EOL and 1.8 has been out for the last few years, I no longer see a reason to mention MyBB's 1.6 requirements. If necessary, users should see 1.6's old documentation.

It may also be wise to bump the recommended PHP version to 7.0 or the planned minimum PHP version in preparation for 1.9x. Opinions?