### PR TITLE
Add Cache Handlers, update Configuration File

### DIFF
--- a/1.8/administration/cache-handlers.md
+++ b/1.8/administration/cache-handlers.md
@@ -1,0 +1,56 @@
+---
+layout: page
+title: "Cache Handlers"
+categories: [administration]
+---
+
+MyBB's [Datacache](/1.8/development/datacache/), fetched from the database by default, can be stored using different cache handlers to improve performance.
+
+You can select which Cache Handler you would like to use on your MyBB installation by editing the [configuration file](/1.8/administration/configuration-file/) (`inc/config.php`) and changing the value of `$config['cache_store']`.
+
+For example, to use the APCu cache store, change the line to:
+```php
+$config['cache_store'] = 'apcu';
+```
+
+
+## Supported Cache Handlers
+- ### Database
+  `db`
+  
+  The default cache handler.
+
+- ### [APC](https://www.php.net/manual/en/book.apc.php)
+  `apc`
+
+  Please note, APC Cache Handler is no longer officially supported.
+
+- ### [APCu](https://www.php.net/manual/en/book.apcu.php)
+  `apcu`
+
+  Please note, APCu is available in MyBB 1.8.23 or higher.
+
+- ### Files
+  `files`
+
+  Cache file are written to the filesystem within the `cache/` directory as PHP files. The `cache/` directory must be writeable for this cache handler to function.
+
+- ### [eAccelerator](https://github.com/eaccelerator/eaccelerator/wiki)
+  `eaccelerator`
+
+  Please note, eAccelerator is no longer officially supported.
+
+- ### [Memcache](https://www.php.net/manual/en/book.memcache.php)
+  `memcache`
+  
+- ### [Memcached](https://github.com/memcached/memcached/wiki)
+  `memcached`
+
+  Please note, you will also need to set the Memcache hostname and port setting for this Cache Handler to work.
+
+- ### [Redis](https://redis.io/documentation)
+ `redis`
+
+  Please note, you will need to set the Redis hostname (`$config['redis']['host']`) and port (`$config['redis']['port']`) setting for this Cache Handler to work.
+  
+  This handler is available in MyBB 1.8.23 or higher.

--- a/1.8/administration/cache-handlers.md
+++ b/1.8/administration/cache-handlers.md
@@ -33,7 +33,7 @@ $config['cache_store'] = 'apcu';
 - ### Files
   `files`
 
-  Cache file are written to the filesystem within the `cache/` directory as PHP files. The `cache/` directory must be writeable for this cache handler to function.
+  Cache files are written to the filesystem within the `cache/` directory as PHP files. The `cache/` directory must be writeable for this cache handler to function.
 
 - ### [eAccelerator](https://github.com/eaccelerator/eaccelerator/wiki)
   `eaccelerator`

--- a/1.8/administration/configuration-file.md
+++ b/1.8/administration/configuration-file.md
@@ -56,7 +56,7 @@ $config['hide_admin_links'] = 0;
  *  By default, the database is used to store this data.
  *
  *  If you wish to use the file system (cache/ directory), MemCache (or MemCached), xcache, APC, or eAccelerator
- *  you can change the value below to 'files', 'memcache', 'memcached', 'xcache', 'apc' or 'eaccelerator' from 'db'.
+ *  you can change the value below to 'files', 'memcache', 'memcached', 'xcache', 'apc', 'apcu', 'eaccelerator' or 'redis' from 'db'
  */
 
 $config['cache_store'] = 'db';
@@ -72,6 +72,18 @@ $config['cache_store'] = 'db';
 
 $config['memcache']['host'] = 'localhost';
 $config['memcache']['port'] = 11211;
+
+/**
+ * Redis configuration
+ *  If you are using Redis as your data-cache
+ *  you need to configure the hostname and port
+ *  of your redis server below. If you want
+ *  to connect via unix sockets, use the full
+ *  path to the unix socket as host and leave
+ *  the port setting unconfigured or false.
+ */
+$config['redis']['host'] = 'localhost';
+$config['redis']['port'] = 6379;
 
 /**
  * Super Administrators

--- a/1.8/development/datacache.md
+++ b/1.8/development/datacache.md
@@ -6,7 +6,7 @@ categories: [development]
 
 # Datacache
 
-Besides dedicated database table structures, MyBB utilizes a data cache system. Cache entries are saved in the `mybb_datacache` table and propagated to [configured](/1.8/administration/configuration-file/) cache store.
+Besides dedicated database table structures, MyBB utilizes a data cache system. Cache entries are saved in the `mybb_datacache` table and propagated to configured [cache store](/1.8/administration/cache-handlers/).
 
 The following table lists default content of the Admin CP's **Tools & Maintenance &rarr; Cache Manager**. Entries with  _Redundancy_ are usually created for performance improvements and can be rebuilt automatically using the database.
 


### PR DESCRIPTION
Based on #193:
- moved instructions to introduction paragraph
- changed titles with emphasis to list with headings (that can be targeted with `#`)
- removed copied text
- added code names
- added Redis configuration variable names
- added `db` handler
- example changed to APCu for simplicity
- code formatted with fenced block ` ```php ` syntax
- minor style edits
- linked the Configuration File article, removed line numbers that may change in the future
- added Datacache reference and article link
- linked the article in Datacache
- updated Configuration File article

Shouldn't be merged until claimed support is present in mentioned versions.